### PR TITLE
Add min: 0 option for age input

### DIFF
--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -21,7 +21,7 @@
 
       <div class="field form-group text-left">
         <small class="label_title"><%= f.label :年齢 %></small><br />
-        <%= f.number_field :age, autofocus: true, autocomplete: "age" ,class:"form-control" %>      
+        <%= f.number_field :age, min: 0, autofocus: true, autocomplete: "age" ,class:"form-control" %>      
       </div>
 
       <div class="field form-group text-left">


### PR DESCRIPTION
## Sumamry 

Login user can select minus age.
This pull request was fix it.

## How to fixed

`number_feild` helper has `min:` and `max:` keyword args.
So, add `min: 0` to `number_field`, can not select minus age.